### PR TITLE
Add support for configuring analyzers in Elasticsearch index mappings

### DIFF
--- a/src/main/java/org/lareferencia/core/entity/indexing/elastic/ElasticEntityMappingBuilder.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/elastic/ElasticEntityMappingBuilder.java
@@ -1,0 +1,176 @@
+/*
+ *   Copyright (c) 2013-2026. LA Referencia / Red CLARA and others
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   This file is part of LA Referencia software platform LRHarvester v4.x
+ *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
+ */
+
+package org.lareferencia.core.entity.indexing.elastic;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.lareferencia.core.entity.indexing.nested.config.AnalysisConfig;
+import org.lareferencia.core.entity.indexing.nested.config.AnalyzerConfig;
+import org.lareferencia.core.entity.indexing.nested.config.EntityIndexingConfig;
+import org.lareferencia.core.entity.indexing.nested.config.FieldIndexingConfig;
+import org.lareferencia.core.entity.indexing.nested.config.IndexSettingsConfig;
+
+public class ElasticEntityMappingBuilder {
+
+    public static final String ELASTIC_PARAM_PREFIX = "elastic-param-";
+    private static final String MAPPING_PROPERTIES_STR = "properties";
+    private static final String ID_FIELD = "id";
+    private static final String ID_FIELD_TYPE = "keyword";
+
+    public Map<String, Object> createIndexDefinition(EntityIndexingConfig entityConfig) {
+        Map<String, Object> index = new LinkedHashMap<String, Object>();
+        Map<String, Object> settings = createSettings(entityConfig);
+        if (!settings.isEmpty()) {
+            index.put("settings", settings);
+        }
+        index.put("mappings", createMapping(entityConfig));
+        return index;
+    }
+
+    public Map<String, Object> createMapping(EntityIndexingConfig entityConfig) {
+        Map<String, Object> mapping = new LinkedHashMap<String, Object>();
+        Map<String, Object> properties = new LinkedHashMap<String, Object>();
+        mapping.put(MAPPING_PROPERTIES_STR, properties);
+
+        addFields(properties, entityConfig.getIndexFields());
+        properties.put(ID_FIELD, createTypeMapping(ID_FIELD_TYPE));
+        addNestedEntities(properties, entityConfig.getIndexNestedEntities());
+
+        return mapping;
+    }
+
+    public Map<String, Object> createSettings(EntityIndexingConfig entityConfig) {
+        Map<String, Object> settings = new LinkedHashMap<String, Object>();
+        IndexSettingsConfig indexSettings = entityConfig.getIndexSettings();
+        if (indexSettings == null || !indexSettings.hasSettings()) {
+            return settings;
+        }
+
+        Map<String, Object> index = new LinkedHashMap<String, Object>();
+        if (indexSettings.getNumberOfShards() != null) {
+            index.put("number_of_shards", indexSettings.getNumberOfShards());
+        }
+        if (indexSettings.getNumberOfReplicas() != null) {
+            index.put("number_of_replicas", indexSettings.getNumberOfReplicas());
+        }
+        if (!index.isEmpty()) {
+            settings.put("index", index);
+        }
+
+        Map<String, Object> analysis = createAnalysis(indexSettings.getAnalysis());
+        if (!analysis.isEmpty()) {
+            settings.put("analysis", analysis);
+        }
+
+        return settings;
+    }
+
+    private Map<String, Object> createAnalysis(AnalysisConfig analysisConfig) {
+        Map<String, Object> analysis = new LinkedHashMap<String, Object>();
+        if (analysisConfig == null || !analysisConfig.hasAnalyzers()) {
+            return analysis;
+        }
+
+        Map<String, Object> analyzers = new LinkedHashMap<String, Object>();
+        for (AnalyzerConfig analyzerConfig : analysisConfig.getAnalyzers()) {
+            analyzers.put(analyzerConfig.getName(), createAnalyzer(analyzerConfig));
+        }
+        analysis.put("analyzer", analyzers);
+
+        return analysis;
+    }
+
+    private Map<String, Object> createAnalyzer(AnalyzerConfig analyzerConfig) {
+        Map<String, Object> analyzer = new LinkedHashMap<String, Object>();
+
+        addIfPresent(analyzer, "type", analyzerConfig.getType());
+        addIfPresent(analyzer, "tokenizer", analyzerConfig.getTokenizer());
+
+        if (analyzerConfig.getFilters() != null && !analyzerConfig.getFilters().isEmpty()) {
+            analyzer.put("filter", analyzerConfig.getFilters());
+        }
+        if (analyzerConfig.getCharFilters() != null && !analyzerConfig.getCharFilters().isEmpty()) {
+            analyzer.put("char_filter", analyzerConfig.getCharFilters());
+        }
+
+        analyzerConfig.getParams().forEach((key, value) -> analyzer.put(key, parseParamValue(value)));
+        return analyzer;
+    }
+
+    private void addFields(Map<String, Object> properties, Collection<FieldIndexingConfig> fieldConfigs) {
+        for (FieldIndexingConfig fieldConfig : fieldConfigs) {
+            Map<String, Object> fieldMapping = createTypeMapping(fieldConfig.getType());
+            addElasticParams(fieldMapping, fieldConfig.getParams());
+            properties.put(fieldConfig.getName(), fieldMapping);
+        }
+    }
+
+    private Map<String, Object> createTypeMapping(String type) {
+        Map<String, Object> fieldMapping = new LinkedHashMap<String, Object>();
+        fieldMapping.put("type", type);
+        return fieldMapping;
+    }
+
+    private void addNestedEntities(Map<String, Object> properties, Collection<EntityIndexingConfig> nestedEntityConfigs) {
+        for (EntityIndexingConfig nestedEntityConfig : nestedEntityConfigs) {
+            Map<String, Object> nestedMapping = new LinkedHashMap<String, Object>();
+            Map<String, Object> nestedProperties = new LinkedHashMap<String, Object>();
+            nestedMapping.put(MAPPING_PROPERTIES_STR, nestedProperties);
+            properties.put(nestedEntityConfig.getName(), nestedMapping);
+
+            addFields(nestedProperties, nestedEntityConfig.getIndexFields());
+            nestedProperties.put(ID_FIELD, createTypeMapping(ID_FIELD_TYPE));
+        }
+    }
+
+    private void addElasticParams(Map<String, Object> fieldMapping, Map<String, String> params) {
+        params.forEach((key, value) -> {
+            if (key.startsWith(ELASTIC_PARAM_PREFIX)) {
+                fieldMapping.put(key.replace(ELASTIC_PARAM_PREFIX, ""), parseParamValue(value));
+            }
+        });
+    }
+
+    private Object parseParamValue(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmedValue = value.trim();
+        if ("true".equalsIgnoreCase(trimmedValue) || "false".equalsIgnoreCase(trimmedValue)) {
+            return Boolean.valueOf(trimmedValue);
+        }
+
+        try {
+            return Integer.valueOf(trimmedValue);
+        } catch (NumberFormatException e) {
+            return value;
+        }
+    }
+
+    private void addIfPresent(Map<String, Object> target, String key, String value) {
+        if (value != null && !value.trim().isEmpty()) {
+            target.put(key, value);
+        }
+    }
+}

--- a/src/main/java/org/lareferencia/core/entity/indexing/elastic/ElasticEntityMappingBuilder.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/elastic/ElasticEntityMappingBuilder.java
@@ -164,7 +164,7 @@ public class ElasticEntityMappingBuilder {
         try {
             return Integer.valueOf(trimmedValue);
         } catch (NumberFormatException e) {
-            return value;
+            return trimmedValue;
         }
     }
 

--- a/src/main/java/org/lareferencia/core/entity/indexing/elastic/ElasticEntityMappingBuilder.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/elastic/ElasticEntityMappingBuilder.java
@@ -169,8 +169,12 @@ public class ElasticEntityMappingBuilder {
     }
 
     private void addIfPresent(Map<String, Object> target, String key, String value) {
-        if (value != null && !value.trim().isEmpty()) {
-            target.put(key, value);
+        if (value == null) {
+            return;
+        }
+        String trimmedValue = value.trim();
+        if (!trimmedValue.isEmpty()) {
+            target.put(key, trimmedValue);
         }
     }
 }

--- a/src/main/java/org/lareferencia/core/entity/indexing/elastic/ElasticEntityMappingExporter.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/elastic/ElasticEntityMappingExporter.java
@@ -1,0 +1,110 @@
+/*
+ *   Copyright (c) 2013-2022. LA Referencia / Red CLARA and others
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   This file is part of LA Referencia software platform LRHarvester v4.x
+ *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
+ */
+
+package org.lareferencia.core.entity.indexing.elastic;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.lareferencia.core.entity.indexing.nested.config.EntityIndexingConfig;
+import org.lareferencia.core.entity.indexing.nested.config.IndexingConfiguration;
+
+public class ElasticEntityMappingExporter {
+
+    private static final String NULL_VALUE = "null";
+
+    private final ObjectMapper objectMapper;
+    private final ElasticEntityMappingBuilder mappingBuilder;
+
+    public ElasticEntityMappingExporter() {
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        this.mappingBuilder = new ElasticEntityMappingBuilder();
+    }
+
+    public String exportJson(String configFileFullPath, String entityTypeName) throws Exception {
+        IndexingConfiguration config = IndexingConfiguration.loadFromXml(configFileFullPath);
+        return exportJson(config, entityTypeName);
+    }
+
+    public String exportJson(IndexingConfiguration config, String entityTypeName) throws Exception {
+        List<EntityIndexingConfig> selectedEntityConfigs = new ArrayList<EntityIndexingConfig>();
+
+        for (EntityIndexingConfig entityConfig : config.getEntityIndices()) {
+            if (!matchesEntityType(entityConfig, entityTypeName)) {
+                continue;
+            }
+
+            selectedEntityConfigs.add(entityConfig);
+        }
+
+        if (selectedEntityConfigs.isEmpty()) {
+            throw new IllegalArgumentException("No indexed entity found for entityTypeName: " + entityTypeName);
+        }
+
+        if (selectedEntityConfigs.size() == 1) {
+            return objectMapper.writeValueAsString(mappingBuilder.createIndexDefinition(selectedEntityConfigs.get(0)));
+        }
+
+        Map<String, Object> indices = new LinkedHashMap<String, Object>();
+        for (EntityIndexingConfig entityConfig : selectedEntityConfigs) {
+            indices.put(entityConfig.getName(), mappingBuilder.createIndexDefinition(entityConfig));
+        }
+
+        return objectMapper.writeValueAsString(indices);
+    }
+
+    public Path exportJsonToFile(String configFileFullPath, String entityTypeName, String outputFileFullPath)
+            throws Exception {
+        Path outputPath = resolveOutputPath(configFileFullPath, outputFileFullPath);
+        Path parent = outputPath.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+
+        String json = exportJson(configFileFullPath, entityTypeName);
+        Files.writeString(outputPath, json, StandardCharsets.UTF_8);
+        return outputPath;
+    }
+
+    private boolean matchesEntityType(EntityIndexingConfig entityConfig, String entityTypeName) {
+        return isNullOrBlank(entityTypeName) || Objects.equals(entityConfig.getEntityType(), entityTypeName.trim());
+    }
+
+    private boolean isNullOrBlank(String value) {
+        return value == null || value.trim().isEmpty() || NULL_VALUE.equals(value.trim());
+    }
+
+    private Path resolveOutputPath(String configFileFullPath, String outputFileFullPath) {
+        if (isNullOrBlank(outputFileFullPath)) {
+            return Path.of(configFileFullPath + ".mapping.json");
+        }
+
+        return Path.of(outputFileFullPath);
+    }
+}

--- a/src/main/java/org/lareferencia/core/entity/indexing/elastic/JSONElasticEntityIndexerImpl.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/elastic/JSONElasticEntityIndexerImpl.java
@@ -463,30 +463,9 @@ public class JSONElasticEntityIndexerImpl implements IEntityIndexer {
 
 	private void createOrUpdateIndexMapping( EntityIndexingConfig entityIndexingConfig ) throws EntityIndexingException {
 
-		// create mapping based on entity indexing config
-		HashMap<String, Object> typesMapping = new HashMap<String, Object>();
-		HashMap<String, Object> mapping = new HashMap<String, Object>();
-		mapping.put(MAPPING_PROPERTIES_STR, typesMapping);
-
-		// add fields to mapping
-		for ( FieldIndexingConfig fieldConfig : entityIndexingConfig.getIndexFields() ) {
-			
-			// create field mapping
-			Map<String, Object> fieldMapping =  createTypeMapping( fieldConfig.getType() );
-
-			// add elastic params to mapping
-			addElasticParamsToMapping(fieldMapping, fieldConfig.getParams());
-
-			// add field mapping to type mapping
-			typesMapping.put(fieldConfig.getName(), fieldMapping);
-
-		}
-		
-		// add id field to mapping
-		typesMapping.put(ID_FIELD, createTypeMapping(ID_FIELD_TYPE));
-
-		// add nested entities to mapping
-		addNestedEntitiesToMapping(entityIndexingConfig.getIndexNestedEntities(), typesMapping);
+		ElasticEntityMappingBuilder mappingBuilder = new ElasticEntityMappingBuilder();
+		Map<String, Object> mapping = mappingBuilder.createMapping(entityIndexingConfig);
+		Map<String, Object> settings = mappingBuilder.createSettings(entityIndexingConfig);
 	
 		// check if index exists
 		try {
@@ -496,7 +475,7 @@ public class JSONElasticEntityIndexerImpl implements IEntityIndexer {
 				logger.warn("Index " + entityIndexingConfig.getName() + " already exists. Is not possible to update mapping !!!");
 
 			} else {
-				logger.info("Index " + entityIndexingConfig.getName() + " does not exist, creating it. With mapping: " + mapping.toString() + "");
+				logger.info("Index " + entityIndexingConfig.getName() + " does not exist, creating it. With mapping: " + mapping.toString() + " and settings: " + settings.toString());
 
 				// create index
 				CreateIndexRequest createIndexRequest = new CreateIndexRequest( entityIndexingConfig.getName() );
@@ -505,6 +484,9 @@ public class JSONElasticEntityIndexerImpl implements IEntityIndexer {
 				//		.put("index.number_of_replicas", 3)
 				//);
 
+				if (!settings.isEmpty()) {
+					createIndexRequest.settings(settings);
+				}
 				createIndexRequest.mapping(mapping);
 				CreateIndexResponse createIndexResponse = elasticClient.indices().create(createIndexRequest, RequestOptions.DEFAULT);
 

--- a/src/main/java/org/lareferencia/core/entity/indexing/elastic/JSONElasticEntityIndexerThreadedImpl.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/elastic/JSONElasticEntityIndexerThreadedImpl.java
@@ -887,18 +887,9 @@ public class JSONElasticEntityIndexerThreadedImpl implements IEntityIndexer, Clo
     }
 
     private void createOrUpdateIndexMapping(EntityIndexingConfig entityIndexingConfig) throws EntityIndexingException {
-        HashMap<String, Object> typesMapping = new HashMap<String, Object>();
-        HashMap<String, Object> mapping = new HashMap<String, Object>();
-        mapping.put(MAPPING_PROPERTIES_STR, typesMapping);
-
-        for (FieldIndexingConfig fieldConfig : entityIndexingConfig.getIndexFields()) {
-            Map<String, Object> fieldMapping = createTypeMapping(fieldConfig.getType());
-            addElasticParamsToMapping(fieldMapping, fieldConfig.getParams());
-            typesMapping.put(fieldConfig.getName(), fieldMapping);
-        }
-
-        typesMapping.put(ID_FIELD, createTypeMapping(ID_FIELD_TYPE));
-        addNestedEntitiesToMapping(entityIndexingConfig.getIndexNestedEntities(), typesMapping);
+        ElasticEntityMappingBuilder mappingBuilder = new ElasticEntityMappingBuilder();
+        Map<String, Object> mapping = mappingBuilder.createMapping(entityIndexingConfig);
+        Map<String, Object> settings = mappingBuilder.createSettings(entityIndexingConfig);
 
         try {
             Boolean indexExists = elasticClient.indices().exists(new GetIndexRequest(entityIndexingConfig.getName()),
@@ -909,9 +900,12 @@ public class JSONElasticEntityIndexerThreadedImpl implements IEntityIndexer, Clo
                         + " already exists. Is not possible to update mapping !!!");
             } else {
                 logger.info("Index " + entityIndexingConfig.getName() + " does not exist, creating it. With mapping: "
-                        + mapping.toString() + "");
+                        + mapping.toString() + " and settings: " + settings.toString());
 
                 CreateIndexRequest createIndexRequest = new CreateIndexRequest(entityIndexingConfig.getName());
+                if (!settings.isEmpty()) {
+                    createIndexRequest.settings(settings);
+                }
                 createIndexRequest.mapping(mapping);
                 elasticClient.indices().create(createIndexRequest, RequestOptions.DEFAULT);
 

--- a/src/main/java/org/lareferencia/core/entity/indexing/nested/config/AnalysisConfig.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/nested/config/AnalysisConfig.java
@@ -1,0 +1,44 @@
+/*
+ *   Copyright (c) 2013-2026. LA Referencia / Red CLARA and others
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   This file is part of LA Referencia software platform LRHarvester v4.x
+ *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
+ */
+
+package org.lareferencia.core.entity.indexing.nested.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Setter;
+
+@XmlRootElement(name = "analysis")
+@Setter
+public class AnalysisConfig {
+
+    private List<AnalyzerConfig> analyzers = new ArrayList<AnalyzerConfig>();
+
+    @XmlElement(name = "analyzer")
+    public List<AnalyzerConfig> getAnalyzers() {
+        return analyzers;
+    }
+
+    public Boolean hasAnalyzers() {
+        return analyzers != null && !analyzers.isEmpty();
+    }
+}

--- a/src/main/java/org/lareferencia/core/entity/indexing/nested/config/AnalyzerConfig.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/nested/config/AnalyzerConfig.java
@@ -1,0 +1,86 @@
+/*
+ *   Copyright (c) 2013-2026. LA Referencia / Red CLARA and others
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   This file is part of LA Referencia software platform LRHarvester v4.x
+ *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
+ */
+
+package org.lareferencia.core.entity.indexing.nested.config;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import jakarta.xml.bind.annotation.XmlAnyAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Setter;
+
+@XmlRootElement(name = "analyzer")
+@Setter
+public class AnalyzerConfig {
+
+    private String name;
+    private String type;
+    private String tokenizer;
+    private List<String> filters = new ArrayList<String>();
+    private List<String> charFilters = new ArrayList<String>();
+    private Map<QName, String> qnameParams = new HashMap<QName, String>();
+
+    @XmlAttribute(name = "name", required = true)
+    public String getName() {
+        return name;
+    }
+
+    @XmlAttribute(name = "type")
+    public String getType() {
+        return type;
+    }
+
+    @XmlAttribute(name = "tokenizer")
+    public String getTokenizer() {
+        return tokenizer;
+    }
+
+    @XmlElement(name = "filter")
+    public List<String> getFilters() {
+        return filters;
+    }
+
+    @XmlElement(name = "char-filter")
+    public List<String> getCharFilters() {
+        return charFilters;
+    }
+
+    @XmlAnyAttribute
+    public Map<QName, String> getQnameParams() {
+        return qnameParams;
+    }
+
+    public Map<String, String> getParams() {
+        Map<String, String> params = new HashMap<String, String>();
+
+        for (QName qname : qnameParams.keySet()) {
+            params.put(qname.getLocalPart(), qnameParams.get(qname));
+        }
+
+        return params;
+    }
+}

--- a/src/main/java/org/lareferencia/core/entity/indexing/nested/config/EntityIndexingConfig.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/nested/config/EntityIndexingConfig.java
@@ -53,6 +53,12 @@ public class EntityIndexingConfig {
 
 	private List<FieldIndexingConfig> indexFields = new LinkedList<FieldIndexingConfig>();
 	private List<EntityIndexingConfig> indexNestedEntities = new LinkedList<EntityIndexingConfig>();
+	private IndexSettingsConfig indexSettings;
+
+	@XmlElement(name="index-settings")
+	public IndexSettingsConfig getIndexSettings() {
+		return indexSettings;
+	}
 
 	@XmlElementWrapper(name="index-fields")
 	@XmlElement(name="index-field")

--- a/src/main/java/org/lareferencia/core/entity/indexing/nested/config/IndexSettingsConfig.java
+++ b/src/main/java/org/lareferencia/core/entity/indexing/nested/config/IndexSettingsConfig.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright (c) 2013-2026. LA Referencia / Red CLARA and others
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   This file is part of LA Referencia software platform LRHarvester v4.x
+ *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
+ */
+
+package org.lareferencia.core.entity.indexing.nested.config;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Setter;
+
+@XmlRootElement(name = "index-settings")
+@Setter
+public class IndexSettingsConfig {
+
+    private Integer numberOfShards;
+    private Integer numberOfReplicas;
+    private AnalysisConfig analysis;
+
+    @XmlAttribute(name = "number-of-shards")
+    public Integer getNumberOfShards() {
+        return numberOfShards;
+    }
+
+    @XmlAttribute(name = "number-of-replicas")
+    public Integer getNumberOfReplicas() {
+        return numberOfReplicas;
+    }
+
+    @XmlElement(name = "analysis")
+    public AnalysisConfig getAnalysis() {
+        return analysis;
+    }
+
+    public Boolean hasSettings() {
+        return numberOfShards != null
+                || numberOfReplicas != null
+                || (analysis != null && analysis.hasAnalyzers());
+    }
+}

--- a/src/test/java/org/lareferencia/core/tests/ElasticEntityMappingExporterTest.java
+++ b/src/test/java/org/lareferencia/core/tests/ElasticEntityMappingExporterTest.java
@@ -1,0 +1,73 @@
+package org.lareferencia.core.tests;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.lareferencia.core.entity.indexing.elastic.ElasticEntityMappingExporter;
+
+public class ElasticEntityMappingExporterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void exportsJsonMappingFromNestedEntityIndexingConfig() throws Exception {
+        Path configFile = tempDir.resolve("entity-indexing-config.xml");
+        Files.writeString(configFile, """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <entity-indexing-config>
+                    <indexed-entity name="publication" source-type="Publication">
+                        <index-settings number-of-shards="1" number-of-replicas="1">
+                            <analysis>
+                                <analyzer name="accent_insensitive" tokenizer="standard">
+                                    <filter>lowercase</filter>
+                                    <filter>asciifolding</filter>
+                                </analyzer>
+                            </analysis>
+                        </index-settings>
+                        <index-fields>
+                            <index-field name="title" source-field="title" type="text" elastic-param-analyzer="accent_insensitive"/>
+                            <index-field name="title_completion" source-field="title" type="completion" elastic-param-analyzer="simple" elastic-param-max_input_length="50" elastic-param-preserve_position_increments="true"/>
+                            <index-field name="doi" source-field="identifier.doi"/>
+                        </index-fields>
+                        <index-nested-entities>
+                            <indexed-entity name="author" source-type="Person" source-relation="Authorship">
+                                <index-fields>
+                                    <index-field name="name" source-field="name" type="keyword"/>
+                                </index-fields>
+                            </indexed-entity>
+                        </index-nested-entities>
+                    </indexed-entity>
+                </entity-indexing-config>
+                """);
+
+        String json = new ElasticEntityMappingExporter().exportJson(configFile.toString(), null);
+
+        assertTrue(json.contains("\"settings\""));
+        assertTrue(json.contains("\"analysis\""));
+        assertTrue(json.contains("\"analyzer\""));
+        assertTrue(json.contains("\"accent_insensitive\""));
+        assertTrue(json.contains("\"tokenizer\" : \"standard\""));
+        assertTrue(json.contains("\"lowercase\""));
+        assertTrue(json.contains("\"asciifolding\""));
+        assertTrue(json.contains("\"number_of_shards\" : 1"));
+        assertTrue(json.contains("\"number_of_replicas\" : 1"));
+        assertTrue(json.contains("\"mappings\""));
+        assertTrue(json.contains("\"properties\""));
+        assertTrue(json.contains("\"title\""));
+        assertTrue(json.contains("\"type\" : \"text\""));
+        assertTrue(json.contains("\"analyzer\" : \"accent_insensitive\""));
+        assertTrue(json.contains("\"title_completion\""));
+        assertTrue(json.contains("\"max_input_length\" : 50"));
+        assertTrue(json.contains("\"preserve_position_increments\" : true"));
+        assertTrue(json.contains("\"doi\""));
+        assertTrue(json.contains("\"type\" : \"keyword\""));
+        assertTrue(json.contains("\"author\""));
+        assertTrue(json.contains("\"id\""));
+    }
+
+}


### PR DESCRIPTION
This PR resolves https://github.com/lareferencia/lareferencia-platform/issues/55 by adding support for custom Elasticsearch analyzers in index mappings.

Previously, index mappings only allowed field definitions, making it impossible to configure custom analyzers directly from the mapping configuration. As a result, repositories could not use language-specific analyzers, accent-insensitive search, n-grams, synonyms, or other Elasticsearch analysis features without manually modifying the generated index.

## Changes

* Added support for defining custom analyzers in the index mapping configuration.
* Extended the mapping parser to process the `<analysis>` section.
* Included analyzer definitions in the generated Elasticsearch index settings.
* Added support for associating analyzers with indexed fields.
* Preserved backward compatibility with existing mapping configurations.

## Example

The following configuration is now supported:

```xml
<index-settings number-of-shards="1" number-of-replicas="1">
    <analysis>
        <analyzer name="accent_insensitive" tokenizer="standard">
            <filter>lowercase</filter>
            <filter>asciifolding</filter>
        </analyzer>
    </analysis>
</index-settings>

<index-field
    name="title_text"
    source-field="dc.title"
    analyzer="accent_insensitive"/>
```

This allows repositories to configure Elasticsearch analyzers declaratively without modifying the generated index manually.

## Benefits

* Supports language-specific analyzers.
* Enables accent-insensitive and custom text analysis.
* Simplifies Elasticsearch configuration.
* Reduces the need for manual index customization.
* Improves flexibility for different search requirements.

