### PR TITLE
Add entity deleted flag

### DIFF
--- a/src/main/java/org/lareferencia/core/entity/domain/Entity.java
+++ b/src/main/java/org/lareferencia/core/entity/domain/Entity.java
@@ -97,6 +97,12 @@ public class Entity extends BaseEntity<Relation> implements ICacheableEntity<UUI
 	@Column(name = "dirty")
 	private Boolean dirty = true;
 
+	@Setter
+	@Getter
+	@JsonIgnore
+	@Column(name = "deleted", nullable = false)
+	private Boolean deleted = false;
+
 	
 
 	/**

--- a/src/main/java/org/lareferencia/core/entity/repositories/jpa/EntityRepository.java
+++ b/src/main/java/org/lareferencia/core/entity/repositories/jpa/EntityRepository.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.time.LocalDateTime;
+import java.util.Collection;
 
 import org.lareferencia.core.entity.domain.Entity;
 import org.lareferencia.core.entity.domain.EntityType;
@@ -33,6 +34,7 @@ import org.lareferencia.core.entity.domain.RelationId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
@@ -69,17 +71,17 @@ public interface EntityRepository extends JpaRepository<Entity, UUID> {
 
 	// Entity Paginator methods
 
-	Page<Entity> findDistinctEntityByDirtyOrderByIdAsc(Boolean dirty, Pageable pageable);
+	Page<Entity> findDistinctEntityByDirtyAndDeletedOrderByIdAsc(Boolean dirty, Boolean deleted, Pageable pageable);
 
-	Page<Entity> findDistinctEntityByDirtyAndEntityTypeOrderByIdAsc(Boolean dirty, EntityType type, Pageable pageable);
+	Page<Entity> findDistinctEntityByDirtyAndDeletedAndEntityTypeOrderByIdAsc(Boolean dirty, Boolean deleted, EntityType type, Pageable pageable);
 
-	Page<Entity> findDistinctEntityByDirtyAndSourceEntities_Provenance_SourceOrderByIdAsc(Boolean dirty, String source, Pageable pageable);
+	Page<Entity> findDistinctEntityByDirtyAndDeletedAndSourceEntities_Provenance_SourceOrderByIdAsc(Boolean dirty, Boolean deleted, String source, Pageable pageable);
 
-	Page<Entity> findDistinctEntityByDirtyAndSourceEntities_Provenance_LastUpdateGreaterThanEqualOrderByIdAsc(Boolean dirty, LocalDateTime lastUpdate, Pageable pageable);
+	Page<Entity> findDistinctEntityByDirtyAndDeletedAndSourceEntities_Provenance_LastUpdateGreaterThanEqualOrderByIdAsc(Boolean dirty, Boolean deleted, LocalDateTime lastUpdate, Pageable pageable);
 
-	Page<Entity> findDistinctEntityByDirtyAndEntityTypeIdAndSourceEntities_Provenance_SourceOrderByIdAsc(Boolean Dirty, Long entityTypeId, String source, Pageable pageable);
+	Page<Entity> findDistinctEntityByDirtyAndDeletedAndEntityTypeIdAndSourceEntities_Provenance_SourceOrderByIdAsc(Boolean Dirty, Boolean deleted, Long entityTypeId, String source, Pageable pageable);
 
-	Page<Entity> findDistinctEntityByDirtyAndEntityTypeIdAndSourceEntities_Provenance_LastUpdateGreaterThanEqualOrderByIdAsc(Boolean Dirty, Long entityTypeId, LocalDateTime lastUpdate, Pageable pageable);
+	Page<Entity> findDistinctEntityByDirtyAndDeletedAndEntityTypeIdAndSourceEntities_Provenance_LastUpdateGreaterThanEqualOrderByIdAsc(Boolean Dirty, Boolean deleted, Long entityTypeId, LocalDateTime lastUpdate, Pageable pageable);
 
 
 	// End Entity Paginator methods
@@ -104,7 +106,8 @@ public interface EntityRepository extends JpaRepository<Entity, UUID> {
 	// Set<Relation> getRelationsWithThisEntityAsMember(UUID id, Long relationId);
 
 	@Query("SELECT r FROM Relation r WHERE r.relationType.id = :relationTypeId AND " +
-       "(CASE WHEN :isFromMember = true THEN r.id.fromEntityId ELSE r.id.toEntityId END) = :entityId")
+	   "((:isFromMember = true AND r.id.fromEntityId = :entityId AND r.toEntity.deleted = false) OR " +
+	   "(:isFromMember = false AND r.id.toEntityId = :entityId AND r.fromEntity.deleted = false))")
 	Set<Relation> findRelationsByTypeAndEntityAndMembership(
 		@Param("relationTypeId") Long relationTypeId,
 		@Param("entityId") UUID entityId,
@@ -112,17 +115,18 @@ public interface EntityRepository extends JpaRepository<Entity, UUID> {
 	);
 
 	@Query("SELECT r.id FROM Relation r WHERE r.relationType.id = :relationTypeId AND " +
-	"(CASE WHEN :isFromMember = true THEN r.id.fromEntityId ELSE r.id.toEntityId END) = :entityId")
+	"((:isFromMember = true AND r.id.fromEntityId = :entityId AND r.toEntity.deleted = false) OR " +
+	"(:isFromMember = false AND r.id.toEntityId = :entityId AND r.fromEntity.deleted = false))")
  	Set<RelationId> findRelationsIdsByTypeAndEntityAndMembership(
 	 @Param("relationTypeId") Long relationTypeId,
 	 @Param("entityId") UUID entityId,
 	 @Param("isFromMember") boolean isFromMember
  );
    
-	@Query("Select r.id.toEntityId from Relation r where r.id.fromEntityId = ?1 and r.relationType.id = ?2")
+	@Query("Select r.id.toEntityId from Relation r where r.id.fromEntityId = ?1 and r.relationType.id = ?2 and r.toEntity.deleted = false")
 	Set<UUID> getToEntitiesIdsWithThisEntityInFromMember(UUID id, Long relationId);
 
-	@Query("Select r.id.fromEntityId from Relation r where r.id.toEntityId = ?1 and r.relationType.id = ?2")
+	@Query("Select r.id.fromEntityId from Relation r where r.id.toEntityId = ?1 and r.relationType.id = ?2 and r.fromEntity.deleted = false")
 	Set<UUID> getFromEntitiesIdsWithThisEntityInToMember(UUID id, Long relationId);
 
 	
@@ -151,6 +155,9 @@ public interface EntityRepository extends JpaRepository<Entity, UUID> {
 	@Query(value = "SELECT merge_dirty_entities_and_relations();", nativeQuery = true)
 	void mergeDirtyEntitiesAndRelations();
 
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query(value = "UPDATE entity SET deleted = :deleted WHERE uuid IN (:entityIds)", nativeQuery = true)
+	int updateDeletedByEntityIds(@Param("entityIds") Collection<UUID> entityIds, @Param("deleted") boolean deleted);
 
    
 

--- a/src/main/java/org/lareferencia/core/entity/services/EntityDataService.java
+++ b/src/main/java/org/lareferencia/core/entity/services/EntityDataService.java
@@ -527,6 +527,14 @@ public class EntityDataService {
 			entityRepository.deleteById(entityId);
 	}
 
+	@Transactional
+	public int updateEntitiesDeleted(Collection<UUID> entityIds, boolean deleted) {
+		if (entityIds == null || entityIds.isEmpty())
+			return 0;
+
+		return entityRepository.updateDeletedByEntityIds(entityIds, deleted);
+	}
+
 	/**
 	 * Find or create final entity based on semantic identifiers.
 	 * 

--- a/src/main/java/org/lareferencia/core/entity/workers/EntityPaginator.java
+++ b/src/main/java/org/lareferencia/core/entity/workers/EntityPaginator.java
@@ -130,20 +130,20 @@ public class EntityPaginator implements IPaginator<Entity> {
 		
 		if ( entityType != null )
 			if ( provenanceSource != null )
-				page = entityRepository.findDistinctEntityByDirtyAndEntityTypeIdAndSourceEntities_Provenance_SourceOrderByIdAsc(false, entityType.getId(), provenanceSource, pageable);
+				page = entityRepository.findDistinctEntityByDirtyAndDeletedAndEntityTypeIdAndSourceEntities_Provenance_SourceOrderByIdAsc(false, false, entityType.getId(), provenanceSource, pageable);
 			else
 				if ( lastUdate != null )
-					page = entityRepository.findDistinctEntityByDirtyAndEntityTypeIdAndSourceEntities_Provenance_LastUpdateGreaterThanEqualOrderByIdAsc(false, entityType.getId(), lastUdate, pageable);
+					page = entityRepository.findDistinctEntityByDirtyAndDeletedAndEntityTypeIdAndSourceEntities_Provenance_LastUpdateGreaterThanEqualOrderByIdAsc(false, false, entityType.getId(), lastUdate, pageable);
 				else
-					page = entityRepository.findDistinctEntityByDirtyAndEntityTypeOrderByIdAsc(false, entityType, pageable);
+					page = entityRepository.findDistinctEntityByDirtyAndDeletedAndEntityTypeOrderByIdAsc(false, false, entityType, pageable);
 		else
 			if ( provenanceSource != null )
-				page = entityRepository.findDistinctEntityByDirtyAndSourceEntities_Provenance_SourceOrderByIdAsc(false, provenanceSource, pageable);
+				page = entityRepository.findDistinctEntityByDirtyAndDeletedAndSourceEntities_Provenance_SourceOrderByIdAsc(false, false, provenanceSource, pageable);
 			else
 				if ( lastUdate != null )
-					page = entityRepository.findDistinctEntityByDirtyAndSourceEntities_Provenance_LastUpdateGreaterThanEqualOrderByIdAsc(false, lastUdate, pageable);
+					page = entityRepository.findDistinctEntityByDirtyAndDeletedAndSourceEntities_Provenance_LastUpdateGreaterThanEqualOrderByIdAsc(false, false, lastUdate, pageable);
 				else
-					page = entityRepository.findDistinctEntityByDirtyOrderByIdAsc(false, pageable);
+					page = entityRepository.findDistinctEntityByDirtyAndDeletedOrderByIdAsc(false, false, pageable);
 		
 		this.totalPages = page.getTotalPages();
 		return page;


### PR DESCRIPTION
Issue https://github.com/lareferencia/lareferencia-platform/issues/65

This change adds the `deleted` flag to final entities and uses it to skip logically deleted entities during indexing.

## Changed Areas

- `Entity` now has `deleted=false` by default: [Entity.java (line 100)](lareferencia-platform/lareferencia-entity-lib/src/main/java/org/lareferencia/core/entity/domain/Entity.java:100)
- `index-entities` pagination filters by `dirty=false` and `deleted=false`: [EntityPaginator.java (line 131)](lareferencia-platform/lareferencia-entity-lib/src/main/java/org/lareferencia/core/entity/workers/EntityPaginator.java:131)
- Related/nested entities also skip related entities with `deleted=true`: [EntityRepository.java (line 108)](lareferencia-platform/lareferencia-entity-lib/src/main/java/org/lareferencia/core/entity/repositories/jpa/EntityRepository.java:108)
- Migration created with `deleted boolean NOT NULL DEFAULT FALSE`: [V5.0.0.7__Add_Entity_Deleted_Flag.sql (line 1)](lareferencia-platform/lareferencia-shell/src/main/resources/db/migration/V5.0.0.7__Add_Entity_Deleted_Flag.sql:1)
- Shell command updated to mark entities as deleted from a UUID file: [EntityDataCommands.java (line 297)](lareferencia-platform/lareferencia-shell-entity-plugin/src/main/java/org/lareferencia/shell/commands/entity/EntityDataCommands.java:297)

## Usage

Before using the command against an existing database, run the database migration so the `entity.deleted` column exists:

```bash
database_migrate
```

To mark entities as deleted and skip them in future indexing runs:

```bash
mark_entities_deleted --path /path/to/uuids.txt
```

The file may contain UUIDs separated by lines, spaces, commas, or semicolons. Comments starting with `#` are ignored.

## Revert

To re-enable entities for indexing:

```bash
set_entities_deleted --path /path/to/uuids.txt --deleted false
```

## Expected Behavior

- New entities continue to use `deleted=false`.
- Entities with `deleted=true` are excluded from the main `index-entities` pagination.
- Entities with `deleted=true` are also excluded as related/nested entities in other entity documents.
