### PR TITLE
Remove deleted entities from elasticsearch

### DIFF
--- a/src/main/java/org/lareferencia/core/entity/repositories/jpa/EntityRepository.java
+++ b/src/main/java/org/lareferencia/core/entity/repositories/jpa/EntityRepository.java
@@ -86,6 +86,9 @@ public interface EntityRepository extends JpaRepository<Entity, UUID> {
 
 	// End Entity Paginator methods
 
+	@Query("select e.id from Entity e where e.deleted = true order by e.id")
+	List<UUID> findDeletedEntityIds(Pageable pageable);
+
 	// @Query("Select r.fromEntity from Relation r where r.id.toEntityId = ?1 and r.id.relationTypeId = ?2")
 	// Page<Entity> findRelatedFromEntitesByRelationTypeId(UUID entityId, Long relationTypeId, Pageable pageable);
 

--- a/src/main/java/org/lareferencia/core/entity/services/EntityDataService.java
+++ b/src/main/java/org/lareferencia/core/entity/services/EntityDataService.java
@@ -72,6 +72,7 @@ import org.lareferencia.core.entity.xml.XMLRelationInstance;
 import org.lareferencia.core.util.Profiler;
 import org.lareferencia.core.util.date.DateHelper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Propagation;
@@ -533,6 +534,11 @@ public class EntityDataService {
 			return 0;
 
 		return entityRepository.updateDeletedByEntityIds(entityIds, deleted);
+	}
+
+	@Transactional(readOnly = true)
+	public List<UUID> getDeletedEntityIds(int page, int pageSize) {
+		return entityRepository.findDeletedEntityIds(PageRequest.of(page, pageSize));
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://github.com/lareferencia/lareferencia-platform/issues/65

## Elasticsearch Cleanup

To remove already-indexed deleted entities from one index, and remove nested references to those deleted IDs from documents in that same index:

```bash
remove_deleted_entities_from_index --indexName brc-nov2025-person
```

Run the command once per target index that must be cleaned.